### PR TITLE
Add ExemptIPAddresses setting

### DIFF
--- a/Samples/ConnectionLimit/PatchClass.cs
+++ b/Samples/ConnectionLimit/PatchClass.cs
@@ -116,7 +116,11 @@ namespace ConnectionLimit
                     connections.Add(address, 1);
                 else connections[address]++;
 
-                if (connections[address] > Settings.MaxNonExempt)
+
+                //Maximum connections are from ExemptIPAddress in Config.js or if not present the default value MaxNonExempt
+                int maxConnections = Settings.ExemptIPAddresses.ContainsKey(address.ToString()) ? Settings.ExemptIPAddresses[address.ToString()] : Settings.MaxNonExempt;
+
+                if (connections[address] > maxConnections)
                 {
                     player.SendMessage($"Booting due to exceeding {Settings.MaxNonExempt} allowed outside of exempt areas.");
                     player.Session.LogOffPlayer();

--- a/Samples/ConnectionLimit/Readme.md
+++ b/Samples/ConnectionLimit/Readme.md
@@ -2,6 +2,7 @@
 
 *  `MaxNonExempt` sets a limit for players outside of exempt landblocks.  
   Increase the number of allowed ACE connections and use this setting for the number of "active" connections.
+* `ExemptIPAddresses` sets the allowed connections per IP address. This is an object with the keys being IP addresses and the value being an integer of the number of allowed connections.
 * `ExemptLandblocks` is a set of [landblocks](https://docs.google.com/spreadsheets/d/122xOw3IKCezaTDjC_hggWSVzYJ_9M_zUUtGEXkwNXfs/edit#gid=734303881) that will be exempt from this limit.
 * `Interval` is the number of seconds between checks for players that exceed the limit.  
 

--- a/Samples/ConnectionLimit/Settings.cs
+++ b/Samples/ConnectionLimit/Settings.cs
@@ -8,6 +8,9 @@ public class Settings
     //Number of seconds between checking
     public double Interval { get;  set; } = 10;
 
+    //IP addresses with the number of allowed connections that are exempt
+    public Dictionary<string, int> ExemptIPAddresses { get; set; } = new();
+
     //Landblocks that are exempt
     public HashSet<ushort> ExemptLandblocks { get; set; } = new()
         {


### PR DESCRIPTION
Adds the `ExemptIPAddresses` setting to Settings.json. This allows the ability to set a custom amount of connections per IP address.

The intention is for the default maximum amount of connections to be handled with `MaxNonExempt` but to allow for extra connections to account for houses with multiple people playing with the same IP address.