### PR TITLE
Realms: Fixes for BinaryWriter.Write(ulong) and global usings

### DIFF
--- a/ACE.Shared/GlobalUsings.cs
+++ b/ACE.Shared/GlobalUsings.cs
@@ -21,6 +21,8 @@ global using ACE.Server.WorldObjects.Entity;
 global using ACE.Server.WorldObjects;
 #if REALM
 global using ACE.Server.Realms;
+global using Session = ACE.Server.Network.ISession;
+global using BinaryWriter = ACE.Server.Network.GameMessages.RealmsBinaryWriter;
 #endif
 
 global using HarmonyLib;

--- a/ACE.Shared/Helpers/GameMessageExtensions.cs
+++ b/ACE.Shared/Helpers/GameMessageExtensions.cs
@@ -33,7 +33,7 @@ public static void Base(this GameEventMessage eventMessage, Session session, Gam
         gameMessage.Opcode = opCode;
         gameMessage.Group = group;
         gameMessage.Data = new System.IO.MemoryStream();
-        gameMessage.Writer = new System.IO.BinaryWriter(gameMessage.Data);
+        gameMessage.Writer = new BinaryWriter(gameMessage.Data);
 
         if (gameMessage.Opcode != GameMessageOpcode.None)
             gameMessage.Writer.Write((uint)gameMessage.Opcode);

--- a/Samples/Expansion/GlobalUsings.cs
+++ b/Samples/Expansion/GlobalUsings.cs
@@ -38,3 +38,7 @@ global using Spell = ACE.Server.Entity.Spell;
 //Aliases for polluted types
 global using Mutation = Expansion.Enums.Mutation;
 global using S = Expansion.PatchClass;
+#if REALM
+global using Session = ACE.Server.Network.ISession;
+global using BinaryWriter = ACE.Server.Network.GameMessages.RealmsBinaryWriter;
+#endif

--- a/Samples/Tower/Debit.cs
+++ b/Samples/Tower/Debit.cs
@@ -25,7 +25,7 @@ public class Debit
         //Workaround initialization since base is awkward..?
         __instance.Base(session, GameEventType.ApproachVendor, GameMessageGroup.UIQueue);
 
-        __instance.Writer.Write(vendor.Guid.Full);
+        __instance.Writer.WriteGuid(vendor.Guid);
 
         // the types of items vendor will purchase
         __instance.Writer.Write((uint)vendor.MerchandiseItemTypes);

--- a/Samples/Tower/GlobalUsings.cs
+++ b/Samples/Tower/GlobalUsings.cs
@@ -31,5 +31,7 @@ global using System.Text.Json.Serialization;
 global using System.Text.Json;
 global using System.Text.RegularExpressions;
 global using System.Text;
-global using ACE.Shared;
-global using ACE.Shared.Helpers;
+#if REALM
+global using Session = ACE.Server.Network.ISession;
+global using BinaryWriter = ACE.Server.Network.GameMessages.RealmsBinaryWriter;
+#endif


### PR DESCRIPTION
Fixes a vendor crash
Adds some global usings (should eliminate the need to switch to ISession more than once per project)

The v2.1 (and master) branch in ACRealms now includes a compiler extension to automatically fail a compilation if RealmsBinaryWriter.Write(UInt64) is used. 

To use the analyzer from a project other than ACE.Server.csproj:
```
<ProjectReference Include="path\to\ACRealms.WorldServer\Source\ACRealms.RoslynAnalyzer\ACRealms.RoslynAnalyzer\ACRealms.RoslynAnalyzer.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
```

Should be possible to use dll reference in the same way 